### PR TITLE
CORE-1897 Update token formatting for Tapis v3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,5 @@ pom.xml.asc
 /.nrepl-port
 build.xml
 test2junit
+.idea
+*.iml

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject org.cyverse/authy "2.8.1-SNAPSHOT"
+(defproject org.cyverse/authy "3.0.0-SNAPSHOT"
   :description "An OAuth 2.0 client clibrary written in Clojure."
   :url "https://github.com/cyverse-de/authy"
   :license {:name "BSD Standard License"

--- a/src/authy/core.clj
+++ b/src/authy/core.clj
@@ -1,7 +1,6 @@
 (ns authy.core
   (:use [slingshot.slingshot :only [throw+ try+]])
   (:require [clj-http.client :as http]
-            [clojure.string :as string]
             [clojure.tools.logging :as log])
   (:import [java.io IOException]
            [java.sql Timestamp]))
@@ -15,12 +14,11 @@
   token-info)
 
 (defn- format-token-info
-  [token-info]
-  (assoc (dissoc token-info :token_type :expires_in :refresh_token :access_token)
-    :token-type    (:token_type token-info)
-    :expires-at    (Timestamp. (+ (System/currentTimeMillis) (* 1000 (:expires_in token-info))))
-    :refresh-token (:refresh_token token-info)
-    :access-token  (:access_token token-info)))
+  [{:keys [access_token refresh_token]}]
+  {:token-type    "bearer"
+   :expires-at    (Timestamp. (+ (System/currentTimeMillis) (* 1000 (:expires_in access_token))))
+   :refresh-token (:refresh_token refresh_token)
+   :access-token  (:access_token access_token)})
 
 (defn- auth-code-token-request
   [{:keys [token-uri redirect-uri client-key client-secret]} code timeout]
@@ -36,15 +34,16 @@
 (defn get-access-token
   [oauth-info code & {:keys [timeout] :or {timeout 5000}}]
   (->> (auth-code-token-request oauth-info code timeout)
+       :result
        (format-token-info)
        (merge oauth-info)
        (call-token-callback)))
 
 (defn- credentials-token-request
-  [{:keys [token-uri redirect-uri client-key client-secret]} username password timeout]
+  [{:keys [token-uri client-key client-secret]} username password timeout]
   (:body (http/post token-uri
                     {:basic-auth     [client-key client-secret]
-                     :form-params    {:grant_type "client_credentials"
+                     :form-params    {:grant_type "password"
                                       :username   username
                                       :password   password}
                      :as             :json
@@ -54,6 +53,7 @@
 (defn get-access-token-for-credentials
   [oauth-info username password & {:keys [timeout] :or {timeout 5000}}]
   (->> (credentials-token-request oauth-info username password timeout)
+       :result
        (format-token-info)
        (merge oauth-info)
        (call-token-callback)))
@@ -104,6 +104,7 @@
 (defn refresh-access-token
   [token-info & {:keys [timeout] :or {timeout 5000}}]
   (->> (refresh-token-request token-info timeout)
+       :result
        (format-token-info)
        (merge token-info)
        (call-token-callback)))

--- a/src/authy/core.clj
+++ b/src/authy/core.clj
@@ -80,8 +80,8 @@
                        :socket-timeout   timeout
                        :throw-exceptions false})
            (:body)
-           (:error)
-           (= "invalid_grant")))
+           (:status)
+           (= "error")))
 
 (defn- check-reauth
   [token-info timeout]

--- a/src/authy/core.clj
+++ b/src/authy/core.clj
@@ -15,8 +15,7 @@
 
 (defn- format-token-info
   [{:keys [access_token refresh_token]}]
-  {:token-type    "bearer"
-   :expires-at    (Timestamp. (+ (System/currentTimeMillis) (* 1000 (:expires_in access_token))))
+  {:expires-at    (Timestamp. (+ (System/currentTimeMillis) (* 1000 (:expires_in access_token))))
    :refresh-token (:refresh_token refresh_token)
    :access-token  (:access_token access_token)})
 


### PR DESCRIPTION
It appears that this lib is currently only used for oauth requests to Agave, but the response formats from Tapis v3 are slightly different.

So this PR will update the parsing and token formatting for the new Tapis v3 responses.

It will also bump this lib's version to 3.0.0.